### PR TITLE
fix: fix #74 `Замяніць пункт меню "Наша дзейнасць" на "Дзейнасць"`

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
 						<li><a href="https://falanster.by/be/arganyzacyja">Фаланстэр</a></li>
 						<li><a href="https://falanster.by/be/volunteers">Валанцёру</a></li>
 						<li><a href="https://falanster.by/be/news">Блог</a></li>
-						<li><a href="https://falanster.by/be/projects_and_clubs">Наша дзейнасць</a></li>
+						<li><a href="https://falanster.by/be/projects_and_clubs">Дзейнасць</a></li>
 						<li><a href="#calendar">Каляндар</a></li>
 						<li><a href="https://wiki.falanster.info/wiki/%D0%9F%D1%80%D0%BE%D1%84i%D0%BB%D1%8C_%D0%A4%D0%B0%D0%BB%D0%B0%D0%BD%D1%81%D1%82%D1%8D%D1%80%D0%B0https://wiki.falanster.info/wiki/%D0%97%D0%B0%D0%B3%D0%BB%D0%B0%D0%B2%D0%BD%D0%B0%D1%8F_%D1%81%D1%82%D1%80%D0%B0%D0%BD%D0%B8%D1%86%D0%B0">Wiki</a></li>
 						<li><a href="http://falanster.by/be/partners">Партнерства</a></li>
@@ -93,7 +93,7 @@
 					<div class="list_item" id="item1"><li><a href="https://falanster.by/be/arganyzacyja">Фаланстэр</a></li></div>
 					<div class="list_item" id="item2"><li><a href="https://falanster.by/be/volunteers">Валанцеру</a></li></div>
 					<div class="list_item" id="item3"><li><a href="https://falanster.by/be/news">Блог</a></li></div>
-					<div class="list_item" id="item4"><li><a href="https://falanster.by/be/projects_and_clubs">Наша дзейнасць</a></li></div>
+					<div class="list_item" id="item4"><li><a href="https://falanster.by/be/projects_and_clubs">Дзейнасць</a></li></div>
 					<div class="list_item" id="item5"><li><a href="">Каляндар</a></li></div>
 					<div class="list_item" id="item6"><li><a href="https://wiki.falanster.info/wiki/%D0%9F%D1%80%D0%BE%D1%84i%D0%BB%D1%8C_%D0%A4%D0%B0%D0%BB%D0%B0%D0%BD%D1%81%D1%82%D1%8D%D1%80%D0%B0">Wiki</a></li></div>
 					<div class="list_item" id="item7"><li><a href="https://falanster.by/be/ulaziny">Партнерства</a></li></div>


### PR DESCRIPTION
> Дэсктоп і смартфон. Замяніць пункт меню "Наша дзейнасць" на "Дзейнасць", бо пры навядзенні пераносіцца на наступную страку

