### PR TITLE
fix: fix #75 `Гарачыя праекты каб апісанне праектаў па леваму краю.`

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -155,7 +155,6 @@ body{
 	margin: 0 45px 0 43px;
 	color:  #767676;
 	line-height: 1.4;
-	text-align: center;
 }
 
 .info-block p a{


### PR DESCRIPTION
> Дэсктоп. Блок "Гарачыя праекты". Зрабіць, каб апісанне праектаў адлюстроўвалася па леваму краю згодна макету. Зараз пасярэдзяне.