### PR TITLE
fix: fix #135

### DIFF
--- a/css/content.css
+++ b/css/content.css
@@ -1,6 +1,6 @@
 .banner {
 	padding-top: 200px;
-	font-family: 'Ubuntu', Arial, sans-serif;
+  font-family: 'Ubuntu', Arial, sans-serif;
 }
 
 .banner__photo {
@@ -45,19 +45,19 @@
 
 .banner__heading {
 	margin: 0;
-	margin-bottom: 70px;
+	margin-bottom: 60px;
 	font-size: 60px;
-	line-height: normal;
+  line-height: 68px;
+  font-weight: 500;
 }
 
 .banner__info {
 	margin: 0;
-	margin-top: 70px;
 	font-size: 14px;
 }
 
 .banner__date {
-	margin-right: 60px;
+	margin-right: 40px;
 }
 
 .banner__btn-scroll {

--- a/event.html
+++ b/event.html
@@ -173,7 +173,6 @@
             <a class="banner__link banner__link--next" href="#">Наступнае мерапрыемства</a>
           </div>
           
-          <button class="banner__btn-scroll btn-scroll" type="button">Далей</button>
           <p class="banner__date-block">22 cтудзеня 19:00</p>
         </div>
       </div>


### PR DESCRIPTION
> Шрифт заголовка: Ubuntu, medium, 60px, межстрок - 68px.
Заголовок с датай публикации и автором выравнивается по середине между прямоугольником с датой и меню.

> Если появляется вторая строчка, то выравнивание по левому краю рабочей области
Указание автора и даты на расстоянии 60px от заголовка, шрифт Ubuntu Regular 14px. Промежуток от даты до автора 40px. Дата и автор указываются слева на одном уровне с заголовком.

Скролла вниз нет!