### PR TITLE
fix: fix #157

### DIFF
--- a/css/content.css
+++ b/css/content.css
@@ -48,6 +48,10 @@
   line-height: 68px;
   font-weight: 500;
   word-wrap: break-word;
+    -moz-hyphens: auto;
+    -webkit-hyphens: auto;
+    -ms-hyphens: auto;
+  hyphens: auto;
 }
 
 .banner__info {

--- a/css/content.css
+++ b/css/content.css
@@ -47,6 +47,7 @@
 	font-size: 60px;
   line-height: 68px;
   font-weight: 500;
+  word-wrap: break-word;
 }
 
 .banner__info {


### PR DESCRIPTION
![default](https://user-images.githubusercontent.com/38830168/53104055-5cecb180-3537-11e9-81bb-b3ddfe83b9fb.PNG)

> [Унутраная старонка] Адсутнічае мяжа для дліны слова ў загалоўке. Трэба зрабіць, каб слова не выходзіла за межы працоўнай вобласці з тэкстам 778 px #157