### PR TITLE
fix: fix #138 адаптив контентных страниц

### DIFF
--- a/css/content.css
+++ b/css/content.css
@@ -237,6 +237,19 @@
 		padding-top: 200px;
 	}
 
+	.banner__photo {
+		height: calc(92vh - 200px);
+	}
+
+	.banner__photo::before {
+		height: calc(67vh - 200px);
+	}
+
+	.banner__photo::after {
+		position: absolute;
+		top: calc(67vh - 200px);
+	}
+
 	.banner__text--event {
 		left: 5%;
 		font-size: 42px;

--- a/css/content.css
+++ b/css/content.css
@@ -225,3 +225,75 @@
 /* end of hotfix styles */
 
 
+
+/* small screens */
+
+@media (max-width: 1079px) {
+	.content {
+		padding-top: 80px;
+	}
+
+	.banner {
+		padding-top: 200px;
+	}
+
+	.banner__text--event {
+		left: 5%;
+		font-size: 42px;
+		line-height: 52px;
+		transform: translateY(-50%);
+	}
+
+	.banner__heading {
+		font-size: 30px;
+		line-height: 38px;
+	}
+
+	.banner__heading--event {
+		font-size: 42px;
+		line-height: 52px;
+	}
+
+	.banner__info {
+		margin-top: 5px;
+	}
+
+	.banner__date {
+		margin-right: 32px;
+	}
+
+	.banner__date-block,
+	.banner__status {
+		right: 0;
+		width: 50%;
+		height: 56px;
+		font-size: 14px;
+		line-height: 56px;
+	}
+
+	.banner__links {
+		display: none;
+	}
+
+	.banner__btn-scroll {
+		display: none;
+	}
+
+	.content__btn {
+		box-sizing: border-box;
+		display: block;
+		width: 100%;
+		padding: 25px;
+		line-height: 18px;
+	}
+
+	.content__text p {
+		line-height: 1.5em;
+	}
+
+	.content__text img {
+		width: 110%;
+		margin-left: -5%;
+	}
+}
+

--- a/css/style.css
+++ b/css/style.css
@@ -413,16 +413,21 @@ body {
 	margin: 0 auto;
 }
 
+.container-inner {
+	width: 778px;
+	margin: 0 auto;
+}
+
 @media (max-width: 1079px) {
 	.container {
 		width: 100%;
 		margin: 0;
 	}
-}
 
-.container-inner {
-	width: 778px;
-	margin: 0 auto;
+	.container-inner {
+		width: 91%;
+		margin: 0 auto;
+	}
 }
 
 .visually-hidden:not(:focus):not(:active) {

--- a/event.html
+++ b/event.html
@@ -156,8 +156,8 @@
     <section class="banner">
       <div class="banner__photo" style="background-image: url('./images/event-bg.jpg');">
         <div class="banner__container container-inner">
-          <div class="banner__text">
-            <h1 class="banner__heading">Назва мерапрыемства</h1>
+          <div class="banner__text banner__text--event">
+            <h1 class="banner__heading banner__heading--event">Назва мерапрыемства</h1>
             <p class="banner__info">
               <span class="banner__date">
                 серада, 23.10.2018


### PR DESCRIPTION
@Omeljusik Вопрос в следующем: т.к. изначально верстка была сделана не совсем адаптивно (после 990px сайт просто масштабируется), то при использовании абсолютных значений для размеров шрифтов и прочего все получается очень мелким. Например, вот: https://amoebiusss.github.io/Falanster-site/about.html

Как вариант, можно сделать "на глаз", чтобы было читабельно.

