### PR TITLE
fix: fix #169

### DIFF
--- a/css/calendarstyle.css
+++ b/css/calendarstyle.css
@@ -42,7 +42,7 @@
 
 @media screen and (max-width: 1079px) {
   .calendar {
-    padding: 0 30px;
+    padding: 60px 30px 0 30px;
     margin: 0;
     text-shadow: none;
   }


### PR DESCRIPTION
> [Галоўная старонка. Мабільная версія] Выправіць размяшчэнне загалоўка "Каляндар". Зараз як быццам закрэсліны палосачкамі злева. #169