### PR TITLE
fix: banner__status font-size and position (mobile)

### DIFF
--- a/css/content.css
+++ b/css/content.css
@@ -418,8 +418,20 @@
 		width: 50%;
 		height: 100px;
 		font-size: 2.25em;
-    line-height: 100px;
-  }
+		line-height: 100px;
+		display: -webkit-box;
+		display: -ms-flexbox;
+		display: flex;
+		justify-content: center;
+		align-items: center;
+	}
+	
+	.banner__status--process .banner__status-icon {
+		display: inline-block;
+		width: 1.125em;
+		height: 1.125em;
+		margin-left: 0.5em;
+	}
 
   .banner__text {
     top: 32.5%;


### PR DESCRIPTION
Этот PR увеличивает размер иконки (шрифт увеличен в пред PR) для мобильной версии, и исправляет баг с позиционированием по центру (вертикаль/горизонталь)

![Снимок](https://user-images.githubusercontent.com/38830168/54496759-a5f81180-48fb-11e9-8cbc-1b399a644642.PNG)
