### PR TITLE
fix: fix default link styles Chrome

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2,6 +2,10 @@ body {
 	font-family: 'Ubuntu', Arial, sans-serif;
 }
 
+a {
+	text-decoration-skip-ink: none;
+}
+
 @media screen and (min-width: 2200px) {
 	.projects__items {
 		display: -webkit-box;


### PR DESCRIPTION
Этот PR сбросит разрыв подчеркивания для ссылок в Chrome.

Было:
![Снимок](https://user-images.githubusercontent.com/38830168/54497366-7b5d8700-4902-11e9-853c-38228cc305f8.PNG)

Станет:
![Снимок2](https://user-images.githubusercontent.com/38830168/54497370-81ebfe80-4902-11e9-865f-1b3fb54c5ac8.PNG)
